### PR TITLE
Add support for synthetic monitoring from JSON input

### DIFF
--- a/grafana_synthetic_check/main.tf
+++ b/grafana_synthetic_check/main.tf
@@ -2,36 +2,6 @@
 data "grafana_synthetic_monitoring_probes" "main" {}
 
 
-variable "job" {
-  description = "The job name to associate the check with"
-  type        = string
-}
-
-variable "target" {
-  description = "The target to check"
-  type        = string
-}
-
-variable "is_enabled" {
-  description = "Whether the check is enabled"
-  type        = bool
-  default     = false
-}
-
-variable "labels" {
-  description = "A map of labels to associate with the check"
-  type        = map(string)
-  default     = {}
-}
-
-# variable "settings" {
-#   description = "The settings for the check"
-#   type = object({
-#     http = object({
-#       method = string
-#     })
-#   })
-# }
 resource "grafana_synthetic_monitoring_check" "http" {
 
   job     = var.job
@@ -67,33 +37,3 @@ variable "http_check_settings" {
     no_follow_redirects = optional(bool, false)
   })
 }
-
-# basic_auth (Block Set, Max: 1) Basic auth settings. (see below for nested schema)
-# bearer_token (String) Token for use with bearer authorization header.
-# body (String) The body of the HTTP request used in probe.
-# cache_busting_query_param_name (String) The name of the query parameter used to prevent the server from using a cached response. Each probe will assign a random value to this parameter each time a request is made.
-# fail_if_body_matches_regexp (Set of String) List of regexes. If any match the response body, the check will fail.
-# fail_if_body_not_matches_regexp (Set of String) List of regexes. If any do not match the response body, the check will fail.
-# fail_if_header_matches_regexp (Block Set) Check fails if headers match. (see below for nested schema)
-# fail_if_header_not_matches_regexp (Block Set) Check fails if headers do not match. (see below for nested schema)
-# fail_if_not_ssl (Boolean) Fail if SSL is not present. Defaults to false.
-# fail_if_ssl (Boolean) Fail if SSL is present. Defaults to false.
-# headers (Set of String) The HTTP headers set for the probe.
-# ip_version (String) Options are V4, V6, Any. Specifies whether the corresponding check will be performed using IPv4 or IPv6. The Any value indicates that IPv6 should be used, falling back to IPv4 if that's not available. Defaults to V4.
-# method (String) Request method. One of GET, CONNECT, DELETE, HEAD, OPTIONS, POST, PUT, TRACE Defaults to GET.
-# no_follow_redirects (Boolean) Do not follow redirects. Defaults to false.
-# proxy_connect_headers (Set of String) The HTTP headers sent to the proxy URL
-# proxy_url (String) Proxy URL.
-# tls_config (Block Set, Max: 1) TLS config. (see below for nested schema)
-# valid_http_versions (Set of String) List of valid HTTP versions. Options include HTTP/1.0, HTTP/1.1, HTTP/2.0
-# valid_status_codes (Set
-
-# /api/v1/register/install
-
-
-
-# GET http://xxxx.grafana.com/api/dashboards/db/mydash HTTP/1.1
-
-# data "grafana_cloud_stack" "test" {
-#   slug = "samdisandbox"
-# }

--- a/grafana_synthetic_check/main.tf
+++ b/grafana_synthetic_check/main.tf
@@ -16,9 +16,12 @@ resource "grafana_synthetic_monitoring_check" "http" {
   settings {
     http {
       method = var.http_check_settings.method
-      basic_auth {
-        username = var.http_check_settings.basic_auth.username
-        password = var.http_check_settings.basic_auth.password
+      dynamic "basic_auth" {
+        for_each = var.http_check_settings.basic_auth != null ? [var.http_check_settings.basic_auth] : []
+        content {
+          username = var.http_check_settings.basic_auth.username
+          password = var.http_check_settings.basic_auth.password
+        }
       }
       valid_status_codes  = var.http_check_settings.valid_status_codes
       no_follow_redirects = var.http_check_settings.no_follow_redirects

--- a/grafana_synthetic_check/main.tf
+++ b/grafana_synthetic_check/main.tf
@@ -1,0 +1,99 @@
+
+data "grafana_synthetic_monitoring_probes" "main" {}
+
+
+variable "job" {
+  description = "The job name to associate the check with"
+  type        = string
+}
+
+variable "target" {
+  description = "The target to check"
+  type        = string
+}
+
+variable "is_enabled" {
+  description = "Whether the check is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "labels" {
+  description = "A map of labels to associate with the check"
+  type        = map(string)
+  default     = {}
+}
+
+# variable "settings" {
+#   description = "The settings for the check"
+#   type = object({
+#     http = object({
+#       method = string
+#     })
+#   })
+# }
+resource "grafana_synthetic_monitoring_check" "http" {
+
+  job     = var.job
+  target  = var.target
+  enabled = var.is_enabled
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt,
+    data.grafana_synthetic_monitoring_probes.main.probes.London,
+  ]
+  labels = var.labels
+
+  settings {
+    http {
+      method = var.http_check_settings.method
+      basic_auth {
+        username = var.http_check_settings.basic_auth.username
+        password = var.http_check_settings.basic_auth.password
+      }
+      valid_status_codes  = var.http_check_settings.valid_status_codes
+      no_follow_redirects = var.http_check_settings.no_follow_redirects
+    }
+  }
+}
+
+variable "http_check_settings" {
+  type = object({
+    method = string                // GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH
+    basic_auth = optional(object({ # Optional
+      username = string
+      password = string
+    }), null)
+    valid_status_codes  = list(number)
+    no_follow_redirects = optional(bool, false)
+  })
+}
+
+# basic_auth (Block Set, Max: 1) Basic auth settings. (see below for nested schema)
+# bearer_token (String) Token for use with bearer authorization header.
+# body (String) The body of the HTTP request used in probe.
+# cache_busting_query_param_name (String) The name of the query parameter used to prevent the server from using a cached response. Each probe will assign a random value to this parameter each time a request is made.
+# fail_if_body_matches_regexp (Set of String) List of regexes. If any match the response body, the check will fail.
+# fail_if_body_not_matches_regexp (Set of String) List of regexes. If any do not match the response body, the check will fail.
+# fail_if_header_matches_regexp (Block Set) Check fails if headers match. (see below for nested schema)
+# fail_if_header_not_matches_regexp (Block Set) Check fails if headers do not match. (see below for nested schema)
+# fail_if_not_ssl (Boolean) Fail if SSL is not present. Defaults to false.
+# fail_if_ssl (Boolean) Fail if SSL is present. Defaults to false.
+# headers (Set of String) The HTTP headers set for the probe.
+# ip_version (String) Options are V4, V6, Any. Specifies whether the corresponding check will be performed using IPv4 or IPv6. The Any value indicates that IPv6 should be used, falling back to IPv4 if that's not available. Defaults to V4.
+# method (String) Request method. One of GET, CONNECT, DELETE, HEAD, OPTIONS, POST, PUT, TRACE Defaults to GET.
+# no_follow_redirects (Boolean) Do not follow redirects. Defaults to false.
+# proxy_connect_headers (Set of String) The HTTP headers sent to the proxy URL
+# proxy_url (String) Proxy URL.
+# tls_config (Block Set, Max: 1) TLS config. (see below for nested schema)
+# valid_http_versions (Set of String) List of valid HTTP versions. Options include HTTP/1.0, HTTP/1.1, HTTP/2.0
+# valid_status_codes (Set
+
+# /api/v1/register/install
+
+
+
+# GET http://xxxx.grafana.com/api/dashboards/db/mydash HTTP/1.1
+
+# data "grafana_cloud_stack" "test" {
+#   slug = "samdisandbox"
+# }

--- a/grafana_synthetic_check/main.tf
+++ b/grafana_synthetic_check/main.tf
@@ -1,5 +1,7 @@
-
-data "grafana_synthetic_monitoring_probes" "this" {}
+data "grafana_synthetic_monitoring_probe" "this" {
+  count = length(var.synthetic_probes)
+  name  = var.synthetic_probes[count.index]
+}
 
 resource "grafana_synthetic_monitoring_check" "http" {
   for_each = { for file in var.synthetic_files : file => jsondecode(file(file))
@@ -10,8 +12,8 @@ resource "grafana_synthetic_monitoring_check" "http" {
   frequency = try(each.value.frequency, 60000)
   timeout   = try(each.value.timeout, 3000)
   probes = [
-    data.grafana_synthetic_monitoring_probes.this.probes.Frankfurt,
-    data.grafana_synthetic_monitoring_probes.this.probes.London,
+    for probe in data.grafana_synthetic_monitoring_probe.this :
+    probe.id
   ]
   labels = try(each.value.labels, {})
 

--- a/grafana_synthetic_check/main.tf
+++ b/grafana_synthetic_check/main.tf
@@ -1,5 +1,5 @@
 
-data "grafana_synthetic_monitoring_probes" "main" {}
+data "grafana_synthetic_monitoring_probes" "this" {}
 
 
 resource "grafana_synthetic_monitoring_check" "http" {
@@ -8,8 +8,8 @@ resource "grafana_synthetic_monitoring_check" "http" {
   target  = var.target
   enabled = var.is_enabled
   probes = [
-    data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt,
-    data.grafana_synthetic_monitoring_probes.main.probes.London,
+    data.grafana_synthetic_monitoring_probes.this.probes.Frankfurt,
+    data.grafana_synthetic_monitoring_probes.this.probes.London,
   ]
   labels = var.labels
 

--- a/grafana_synthetic_check/main.tf
+++ b/grafana_synthetic_check/main.tf
@@ -1,36 +1,33 @@
 
 data "grafana_synthetic_monitoring_probes" "this" {}
 
-
 resource "grafana_synthetic_monitoring_check" "http" {
-
-  job     = var.job
-  target  = var.target
-  enabled = var.is_enabled
+  for_each = { for file in var.synthetic_files : file => jsondecode(file(file))
+  }
+  job       = each.value.job
+  target    = each.value.target
+  enabled   = try(each.value.enabled, true)
+  frequency = try(each.value.frequency, 60000)
+  timeout   = try(each.value.timeout, 3000)
   probes = [
     data.grafana_synthetic_monitoring_probes.this.probes.Frankfurt,
     data.grafana_synthetic_monitoring_probes.this.probes.London,
   ]
-  labels = var.labels
+  labels = try(each.value.labels, {})
 
   settings {
     http {
-      method = upper(var.http_check_settings.method)
-      dynamic "bearer_token" {
-        for_each = var.http_check_settings.bearer_token != null ? [var.http_check_settings.bearer_token] : []
-        content {
-          token = var.http_check_settings.bearer_token.token
-        }
-      }
+      method       = upper(try(each.value.settings.method, "GET"))
+      bearer_token = try(each.value.settings.bearer_token, null)
       dynamic "basic_auth" {
-        for_each = var.http_check_settings.basic_auth != null ? [var.http_check_settings.basic_auth] : []
+        for_each = try([each.value.settings.basic_auth], [])
         content {
-          username = var.http_check_settings.basic_auth.username
-          password = var.http_check_settings.basic_auth.password
+          username = try(each.value.settings.basic_auth.username, null)
+          password = try(each.value.settings.basic_auth.password, null)
         }
       }
-      valid_status_codes  = var.http_check_settings.valid_status_codes
-      no_follow_redirects = var.http_check_settings.no_follow_redirects
+      valid_status_codes  = try(each.value.settings.valid_status_codes, [200])
+      no_follow_redirects = try(each.value.settings.no_follow_redirects, false)
     }
   }
 }

--- a/grafana_synthetic_check/main.tf
+++ b/grafana_synthetic_check/main.tf
@@ -15,7 +15,13 @@ resource "grafana_synthetic_monitoring_check" "http" {
 
   settings {
     http {
-      method = var.http_check_settings.method
+      method = upper(var.http_check_settings.method)
+      dynamic "bearer_token" {
+        for_each = var.http_check_settings.bearer_token != null ? [var.http_check_settings.bearer_token] : []
+        content {
+          token = var.http_check_settings.bearer_token.token
+        }
+      }
       dynamic "basic_auth" {
         for_each = var.http_check_settings.basic_auth != null ? [var.http_check_settings.basic_auth] : []
         content {
@@ -27,16 +33,4 @@ resource "grafana_synthetic_monitoring_check" "http" {
       no_follow_redirects = var.http_check_settings.no_follow_redirects
     }
   }
-}
-
-variable "http_check_settings" {
-  type = object({
-    method = string                // GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH
-    basic_auth = optional(object({ # Optional
-      username = string
-      password = string
-    }), null)
-    valid_status_codes  = list(number)
-    no_follow_redirects = optional(bool, false)
-  })
 }

--- a/grafana_synthetic_check/variables.tf
+++ b/grafana_synthetic_check/variables.tf
@@ -19,3 +19,18 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "http_check_settings" {
+  type = object({
+    method = string                  // GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH
+    bearer_token = optional(object({ # Optional
+      token = string
+    }), null)
+    basic_auth = optional(object({ # Optional
+      username = string
+      password = string
+    }), null)
+    valid_status_codes  = list(number)
+    no_follow_redirects = optional(bool, false)
+  })
+}

--- a/grafana_synthetic_check/variables.tf
+++ b/grafana_synthetic_check/variables.tf
@@ -1,36 +1,9 @@
-variable "job" {
-  description = "The job name to associate the check with"
-  type        = string
-}
-
-variable "target" {
-  description = "The target to check"
-  type        = string
-}
-
-variable "is_enabled" {
-  description = "Whether the check is enabled"
-  type        = bool
-  default     = false
-}
-
-variable "labels" {
-  description = "A map of labels to associate with the check"
-  type        = map(string)
-  default     = {}
-}
-
-variable "http_check_settings" {
-  type = object({
-    method = string                  // GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH
-    bearer_token = optional(object({ # Optional
-      token = string
-    }), null)
-    basic_auth = optional(object({ # Optional
-      username = string
-      password = string
-    }), null)
-    valid_status_codes  = list(number)
-    no_follow_redirects = optional(bool, false)
-  })
+variable "synthetic_files" {
+  description = <<EOF
+    Path to the json files with synthetic monitoring targets.
+    The files must be compliant with the /api/v1/check/add method in
+    https://github.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API.md
+  EOF
+  type        = list(string)
+  default     = []
 }

--- a/grafana_synthetic_check/variables.tf
+++ b/grafana_synthetic_check/variables.tf
@@ -1,0 +1,21 @@
+variable "job" {
+  description = "The job name to associate the check with"
+  type        = string
+}
+
+variable "target" {
+  description = "The target to check"
+  type        = string
+}
+
+variable "is_enabled" {
+  description = "Whether the check is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "labels" {
+  description = "A map of labels to associate with the check"
+  type        = map(string)
+  default     = {}
+}

--- a/grafana_synthetic_check/variables.tf
+++ b/grafana_synthetic_check/variables.tf
@@ -7,3 +7,25 @@ variable "synthetic_files" {
   type        = list(string)
   default     = []
 }
+
+variable "bearer_token" {
+  description = <<EOF
+    Map of bearer tokens for the synthetic monitoring targets.
+    The keys are the synthetic target names and the values are the bearer tokens.
+    Should never be stored in plain text, but should come from a secret manager.
+  EOF
+  type        = map(string)
+  sensitive   = true
+  default     = {}
+}
+
+variable "basic_auth" {
+  description = <<EOF
+    List of username and password combinations for any basic authentication required for the synthetic monitoring targets.
+    The keys are the synthetic target names and the values are new maps of username and password combinations.
+    Should never be stored in plain text, but should come from a secret manager.
+  EOF
+  type        = map(map(string))
+  sensitive   = true
+  default     = {}
+}

--- a/grafana_synthetic_check/variables.tf
+++ b/grafana_synthetic_check/variables.tf
@@ -29,3 +29,20 @@ variable "basic_auth" {
   sensitive   = true
   default     = {}
 }
+
+variable "synthetic_probes" {
+  description = <<EOF
+    List of synthetic monitoring probes to use for the synthetic monitoring targets.
+  EOF
+  type        = list(string)
+  validation {
+    condition     = can(regexall("Amsterdam|Atlanta|Bangalore|CapeTown|Dallas|Frankfurt|London|Mumbai|NewYork|Newark|NorthCalifornia|NorthVirginia|Ohio|Oregon|Paris|SanFrancisco|SaoPaulo|Seoul|Singapore|Sydney|Tokyo|Toronto", join(",", var.synthetic_probes)))
+    error_message = <<EOF
+      Invalid value for log_level. Valid values:
+      Amsterdam, Atlanta, Bangalore, CapeTown, Dallas, Frankfurt, London, Mumbai,
+      NewYork, Newark, NorthCalifornia, NorthVirginia, Ohio, Oregon, Paris,
+      SanFrancisco, SaoPaulo, Seoul, Singapore, Sydney, Tokyo, Toronto
+    EOF
+  }
+  default = ["Frankfurt", "London"]
+}

--- a/grafana_synthetic_check/versions.tf
+++ b/grafana_synthetic_check/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0, < 1.6.0"
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = ">= 2.9.0"
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/dfds/cloudplatform/issues/2622

Accept JSON files that is compliant with the /api/v1/check/add method in   https://github.com/grafana/synthetic-monitoring-api-go-client/blob/main/docs/API.md

Then iterates over the content to create synthetic HTTP checks. 
Any credentials is like basic_auth or bearer_token is not supplied in the file, but rather just a name of a map object. Then the map object can be supplied as TF_VAR_ from a secret.

A sample of such a JSON file can be seen at https://github.com/dfds/grafana-cloud-objects/blob/feature/cloudplatform/issues/2622/synthetics/sandbox/dfds.json