### PR TITLE
Add read only token

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ No modules.
 | [aws_ssm_parameter.grafana_cloud_stack_service_account_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.grafana_cloud_stack_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.otlp_access_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.read_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.sm_access_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.sm_api_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [grafana_cloud_access_policy.otlp](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
+| [grafana_cloud_access_policy.read_only](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
 | [grafana_cloud_access_policy.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
 | [grafana_cloud_access_policy_token.otlp](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy_token) | resource |
+| [grafana_cloud_access_policy_token.read_only](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy_token) | resource |
 | [grafana_cloud_access_policy_token.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy_token) | resource |
 | [grafana_cloud_plugin_installation.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_plugin_installation) | resource |
 | [grafana_cloud_stack.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack) | resource |
@@ -42,11 +45,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_create_read_only_token"></a> [create\_read\_only\_token](#input\_create\_read\_only\_token) | Whether to create a read-only token | `bool` | `false` | no |
 | <a name="input_enable_otlp"></a> [enable\_otlp](#input\_enable\_otlp) | Whether to enable OpenTelemetry | `bool` | `false` | no |
 | <a name="input_grafana_folders"></a> [grafana\_folders](#input\_grafana\_folders) | List of grafana folders to be created | `list(string)` | `[]` | no |
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Name of the hosted zone to contain the route53 record. If unspecified no route53 record is created. | `string` | `null` | no |
 | <a name="input_install_synthetic_monitoring"></a> [install\_synthetic\_monitoring](#input\_install\_synthetic\_monitoring) | Whether to install synthetic monitoring | `bool` | n/a | yes |
-| <a name="input_plugins"></a> [plugins](#input\_plugins) | List of plugins | <pre>list(object({<br>    plugin = string<br>    version = string<br>  }))</pre> | `[]` | no |
+| <a name="input_plugins"></a> [plugins](#input\_plugins) | List of plugins | <pre>list(object({<br>    plugin  = string<br>    version = string<br>  }))</pre> | `[]` | no |
 | <a name="input_region_slug"></a> [region\_slug](#input\_region\_slug) | Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region | `string` | `null` | no |
 | <a name="input_route53_record_name"></a> [route53\_record\_name](#input\_route53\_record\_name) | Name of the route53 record | `string` | `null` | no |
 | <a name="input_slug"></a> [slug](#input\_slug) | Subdomain that the Grafana instance will be available at (i.e. setting slug to empty string will make the instance available at `https://.grafana.net` | `string` | `null` | no |

--- a/route53.tf
+++ b/route53.tf
@@ -1,17 +1,17 @@
 data "aws_route53_zone" "this" {
   provider = aws.route53
-  count = var.hosted_zone_name != null ? 1 : 0
+  count    = var.hosted_zone_name != null ? 1 : 0
 
   name = var.hosted_zone_name
 }
 
 resource "aws_route53_record" "this" {
   provider = aws.route53
-  count = var.hosted_zone_name != null ? 1 : 0
+  count    = var.hosted_zone_name != null ? 1 : 0
 
   zone_id = data.aws_route53_zone.this[count.index].zone_id
-  name = var.route53_record_name
-  type = "CNAME"
-  ttl  = 300
+  name    = var.route53_record_name
+  type    = "CNAME"
+  ttl     = 300
   records = ["${var.slug}.grafana.net"]
 }

--- a/synthetic-monitoring.tf
+++ b/synthetic-monitoring.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "grafana_cloud_access_policy" "this" {
-  count = var.install_synthetic_monitoring ? 1 : 0
+  count    = var.install_synthetic_monitoring ? 1 : 0
   provider = grafana.cloud
 
   region = grafana_cloud_stack.this.region_slug
@@ -16,7 +16,7 @@ resource "grafana_cloud_access_policy" "this" {
 }
 
 resource "grafana_cloud_access_policy_token" "this" {
-  count = var.install_synthetic_monitoring ? 1 : 0
+  count    = var.install_synthetic_monitoring ? 1 : 0
   provider = grafana.cloud
 
   region           = grafana_cloud_stack.this.region_slug
@@ -25,7 +25,7 @@ resource "grafana_cloud_access_policy_token" "this" {
 }
 
 resource "grafana_synthetic_monitoring_installation" "this" {
-  count = var.install_synthetic_monitoring ? 1 : 0
+  count    = var.install_synthetic_monitoring ? 1 : 0
   provider = grafana.cloud
 
   stack_id              = grafana_cloud_stack.this.id
@@ -33,7 +33,7 @@ resource "grafana_synthetic_monitoring_installation" "this" {
 }
 
 resource "aws_ssm_parameter" "sm_access_token" {
-  count = var.install_synthetic_monitoring ? 1 : 0
+  count    = var.install_synthetic_monitoring ? 1 : 0
   provider = aws.route53
 
   name  = "/grafana-cloud/${var.route53_record_name}/sm-access-token"
@@ -42,7 +42,7 @@ resource "aws_ssm_parameter" "sm_access_token" {
 }
 
 resource "aws_ssm_parameter" "sm_api_url" {
-  count = var.install_synthetic_monitoring ? 1 : 0
+  count    = var.install_synthetic_monitoring ? 1 : 0
   provider = aws.route53
 
   name  = "/grafana-cloud/${var.route53_record_name}/sm-api-url"

--- a/variables.tf
+++ b/variables.tf
@@ -1,67 +1,73 @@
 variable "stack_name" {
-  type = string
+  type        = string
   description = "Name of stack"
-  default = null
+  default     = null
 }
 
 variable "slug" {
-  type = string
+  type        = string
   description = "Subdomain that the Grafana instance will be available at (i.e. setting slug to empty string will make the instance available at `https://.grafana.net`"
-  default = null
+  default     = null
 }
 
 variable "region_slug" {
-  type = string
+  type        = string
   description = "Region slug to assign to this stack. Changing region will destroy the existing stack and create a new one in the desired region"
-  default = null
+  default     = null
 }
 
 variable "stack_description" {
-  type = string
+  type        = string
   description = "Description of stack"
-  default = null
+  default     = null
 }
 
 variable "hosted_zone_name" {
-  type = string
+  type        = string
   description = "Name of the hosted zone to contain the route53 record. If unspecified no route53 record is created."
-  default = null
+  default     = null
 }
 
 variable "url" {
-  type = string
+  type        = string
   description = "Custom URL for the Grafana instance. Should not be specified when passing `hosted_zone_name`"
-  default = null
+  default     = null
 }
 
 variable "grafana_folders" {
-  type = list(string)
+  type        = list(string)
   description = "List of grafana folders to be created"
-  default = []
+  default     = []
 }
 
 variable "route53_record_name" {
-  type = string
+  type        = string
   description = "Name of the route53 record"
-  default = null
+  default     = null
 }
 
 variable "plugins" {
   type = list(object({
-    plugin = string
+    plugin  = string
     version = string
   }))
   description = "List of plugins"
-  default = []
+  default     = []
 }
 
 variable "install_synthetic_monitoring" {
-  type = bool
+  type        = bool
   description = "Whether to install synthetic monitoring"
 }
 
 variable "enable_otlp" {
-  type = bool
+  type        = bool
   description = "Whether to enable OpenTelemetry"
-  default = false
+  default     = false
+}
+
+variable "create_read_only_token" {
+  type        = bool
+  description = "Whether to create a read-only token"
+  default     = false
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,13 +1,13 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
-      version = ">= 5.34.0"
+      source                = "hashicorp/aws"
+      version               = ">= 5.34.0"
       configuration_aliases = [aws.route53]
     }
     grafana = {
-      source = "grafana/grafana"
-      version = ">= 2.9.0"
+      source                = "grafana/grafana"
+      version               = ">= 2.9.0"
       configuration_aliases = [grafana.cloud]
     }
   }


### PR DESCRIPTION
Creates a new access policy for the stack with read-only on logs, metrics and traces.
Part of: https://github.com/dfds/cloudplatform/issues/2748