### PR TITLE
add support for creating write-only cloudaccesspolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ No modules.
 | <a name="input_route53_record_name"></a> [route53\_record\_name](#input\_route53\_record\_name) | Name of the route53 record | `string` | `null` | no |
 | <a name="input_slug"></a> [slug](#input\_slug) | Subdomain that the Grafana instance will be available at (i.e. setting slug to empty string will make the instance available at `https://.grafana.net` | `string` | `null` | no |
 | <a name="input_stack_description"></a> [stack\_description](#input\_stack\_description) | Description of stack | `string` | `null` | no |
+| <a name="input_stack_labels"></a> [stack\_labels](#input\_stack\_labels) | Map of labels to apply to the stack | `map(string)` | `{}` | no |
 | <a name="input_stack_name"></a> [stack\_name](#input\_stack\_name) | Name of stack | `string` | `null` | no |
 | <a name="input_stacks_for_multi_stack_querying"></a> [stacks\_for\_multi\_stack\_querying](#input\_stacks\_for\_multi\_stack\_querying) | List of stacks to create access token for multiple stacks | `list(string)` | `[]` | no |
 | <a name="input_teams"></a> [teams](#input\_teams) | List of teams to create with the groups and permissions | <pre>list(object({<br>    name        = string<br>    groups      = list(string)<br>    permissions = list(string)<br>  }))</pre> | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ No modules.
 | [grafana_cloud_access_policy.read_only](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
 | [grafana_cloud_access_policy.read_only_multi_stack](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
 | [grafana_cloud_access_policy.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
+| [grafana_cloud_access_policy.write_only](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
 | [grafana_cloud_access_policy_token.otlp](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy_token) | resource |
 | [grafana_cloud_access_policy_token.read_only](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy_token) | resource |
 | [grafana_cloud_access_policy_token.read_only_multi_stack](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy_token) | resource |
 | [grafana_cloud_access_policy_token.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy_token) | resource |
+| [grafana_cloud_access_policy_token.write_only](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy_token) | resource |
 | [grafana_cloud_plugin_installation.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_plugin_installation) | resource |
 | [grafana_cloud_stack.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack) | resource |
 | [grafana_cloud_stack_service_account.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_stack_service_account) | resource |
@@ -54,6 +56,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create_read_only_token"></a> [create\_read\_only\_token](#input\_create\_read\_only\_token) | Whether to create a read-only token | `bool` | `false` | no |
+| <a name="input_create_write_only_token"></a> [create\_write\_only\_token](#input\_create\_write\_only\_token) | Whether to create a write-only token | `bool` | `false` | no |
 | <a name="input_enable_otlp"></a> [enable\_otlp](#input\_enable\_otlp) | Whether to enable OpenTelemetry | `bool` | `false` | no |
 | <a name="input_grafana_folders"></a> [grafana\_folders](#input\_grafana\_folders) | List of grafana folders to be created | `list(string)` | `[]` | no |
 | <a name="input_hosted_zone_name"></a> [hosted\_zone\_name](#input\_hosted\_zone\_name) | Name of the hosted zone to contain the route53 record. If unspecified no route53 record is created. | `string` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ No modules.
 | [aws_ssm_parameter.read_only_multi_stack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.sm_access_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.sm_api_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.write_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [grafana_cloud_access_policy.otlp](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
 | [grafana_cloud_access_policy.read_only](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |
 | [grafana_cloud_access_policy.read_only_multi_stack](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/cloud_access_policy) | resource |

--- a/stack.tf
+++ b/stack.tf
@@ -14,6 +14,7 @@ resource "grafana_cloud_stack" "this" {
   region_slug = var.region_slug
   description = var.stack_description
   url         = var.hosted_zone_name != null ? "https://${aws_route53_record.this[0].fqdn}" : var.url
+  labels      = var.stack_labels
 }
 
 resource "grafana_cloud_stack_service_account" "this" {

--- a/stack.tf
+++ b/stack.tf
@@ -1,9 +1,9 @@
 locals {
   service_account_name  = "terraform-sa"
-  otlp_name             = "${var.route53_record_name}-otlp-access"
-  read_only_name        = "${var.route53_record_name}-read-only-access"
-  read_only_multi_stack = "${var.route53_record_name}-read-only-multi-stack-access"
-  write_only_name       = "${var.route53_record_name}-write-only-access"
+  otlp_name             = "${var.slug}-otlp-access"
+  read_only_name        = "${var.slug}-read-only-access"
+  read_only_multi_stack = "${var.slug}-read-only-multi-stack-access"
+  write_only_name       = "${var.slug}-write-only-access"
 }
 
 resource "grafana_cloud_stack" "this" {
@@ -36,7 +36,7 @@ resource "grafana_cloud_stack_service_account_token" "this" {
 resource "aws_ssm_parameter" "grafana_cloud_stack_service_account_token" {
   provider = aws.route53
 
-  name  = "/grafana-cloud/${var.route53_record_name}/${local.service_account_name}-access-token"
+  name  = "/grafana-cloud/${var.slug}/${local.service_account_name}-access-token"
   type  = "SecureString"
   value = grafana_cloud_stack_service_account_token.this.key
 }
@@ -44,7 +44,7 @@ resource "aws_ssm_parameter" "grafana_cloud_stack_service_account_token" {
 resource "aws_ssm_parameter" "grafana_cloud_stack_url" {
   provider = aws.route53
 
-  name  = "/grafana-cloud/${var.route53_record_name}/stack-url"
+  name  = "/grafana-cloud/${var.slug}/stack-url"
   type  = "String"
   value = grafana_cloud_stack.this.url
 }
@@ -84,7 +84,7 @@ resource "aws_ssm_parameter" "otlp_access_token" {
   count    = var.enable_otlp ? 1 : 0
   provider = aws.route53
 
-  name  = "/grafana-cloud/${var.route53_record_name}/otlp-access-token"
+  name  = "/grafana-cloud/${var.slug}/otlp-access-token"
   type  = "SecureString"
   value = grafana_cloud_access_policy_token.otlp[0].token
 }
@@ -115,7 +115,7 @@ resource "aws_ssm_parameter" "read_only" {
   count    = var.create_read_only_token ? 1 : 0
   provider = aws.route53
 
-  name  = "/grafana-cloud/${var.route53_record_name}/read-only-access-token"
+  name  = "/grafana-cloud/${var.slug}/read-only-access-token"
   type  = "SecureString"
   value = grafana_cloud_access_policy_token.read_only[0].token
 }
@@ -157,7 +157,7 @@ resource "aws_ssm_parameter" "read_only_multi_stack" {
   count    = length(var.stacks_for_multi_stack_querying) > 0 ? 1 : 0
   provider = aws.route53
 
-  name  = "/grafana-cloud/${var.route53_record_name}/read-only-multi-stack-access-token"
+  name  = "/grafana-cloud/${var.slug}/read-only-multi-stack-access-token"
   type  = "SecureString"
   value = grafana_cloud_access_policy_token.read_only_multi_stack[0].token
 }
@@ -222,11 +222,11 @@ resource "grafana_cloud_access_policy_token" "write_only" {
   name             = local.write_only_name
 }
 
-resource "aws_ssm_parameter" "read_only" {
+resource "aws_ssm_parameter" "write_only" {
   count    = var.create_write_only_token ? 1 : 0
   provider = aws.route53
 
-  name  = "/grafana-cloud/${var.route53_record_name}/write-only-access-token"
+  name  = "/grafana-cloud/${var.slug}/write-only-access-token"
   type  = "SecureString"
-  value = grafana_cloud_access_policy_token.read_only[0].token
+  value = grafana_cloud_access_policy_token.write_only[0].token
 }

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,9 @@ variable "stacks_for_multi_stack_querying" {
   description = "List of stacks to create access token for multiple stacks"
   default     = []
 }
+
+variable "create_write_only_token" {
+  type        = bool
+  description = "Whether to create a write-only token"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,9 @@ variable "create_write_only_token" {
   description = "Whether to create a write-only token"
   default     = false
 }
+
+variable "stack_labels" {
+  type        = map(string)
+  description = "Map of labels to apply to the stack"
+  default     = {}
+}


### PR DESCRIPTION
what:
- write-only tokens for enabling writing data to cloud stacks 
- support  for adding labels to stacks

Context
https://github.com/dfds/cloudplatform/issues/2853