### PR TITLE
feat: add 24h repeat notification policy

### DIFF
--- a/grafana_notification/main.tf
+++ b/grafana_notification/main.tf
@@ -31,5 +31,13 @@ resource "grafana_notification_policy" "this" {
         value = matcher.value.value
       }
     }
+    policy {
+      repeat_interval = "24h"
+      matcher {
+        label = "repeat"
+        match = "eq"
+        value = "24h"
+      }
+    }
   }
 }

--- a/grafana_notification/main.tf
+++ b/grafana_notification/main.tf
@@ -35,7 +35,7 @@ resource "grafana_notification_policy" "this" {
       repeat_interval = "24h"
       matcher {
         label = "repeat"
-        match = "eq"
+        match = "="
         value = "24h"
       }
     }


### PR DESCRIPTION
Adds a 24h interval notification policy. Can be used by adding a repeat = 24h label