### PR TITLE
fix: remove global renovate config options

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "branchPrefix": "feature/renovate/",
-    "username": "devex-sa",
-    "onboarding": false,
-    "platform": "github",
-    "repositories": [
-        "dfds/terraform-grafana-cloud"
-    ],
     "packageRules": [
         {
             "matchUpdateTypes": [


### PR DESCRIPTION
Fixes:

```
WARN: Found renovate config warnings (repository=dfds/terraform-grafana-cloud)
       "warnings": [
         {
           "topic": "Configuration Error",
           "message": "The \"onboarding\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         },
         {
           "topic": "Configuration Error",
           "message": "The \"platform\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         },
         {
           "topic": "Configuration Error",
           "message": "The \"repositories\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         },
         {
           "topic": "Configuration Error",
           "message": "The \"username\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         }
       ]
```