### PR TITLE
Add support for turning on caching by default for Athena data sources

### DIFF
--- a/grafana_data_source_athena/variables.tf
+++ b/grafana_data_source_athena/variables.tf
@@ -2,3 +2,22 @@ variable "data_sources" {
   description = "Path to the json files with data sources"
   type        = list(string)
 }
+
+variable "enable_caching" {
+  description = "Enable caching for the data source"
+  type        = bool
+  default     = true
+}
+
+variable "grafana_url" {
+  description = "URL of the Grafana instance"
+  type        = string
+  default     = ""
+}
+
+variable "bearer_token" {
+  description = "Bearer token for the Grafana API"
+  sensitive   = true
+  type        = string
+  default     = ""
+}

--- a/grafana_data_source_athena/versions.tf
+++ b/grafana_data_source_athena/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "grafana/grafana"
       version = ">= 2.9.0"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 2.9.0"
+    }
   }
 }

--- a/grafana_data_source_athena/versions.tofu
+++ b/grafana_data_source_athena/versions.tofu
@@ -6,5 +6,9 @@ terraform {
       source  = "grafana/grafana"
       version = ">= 2.9.0"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 2.9.0"
+    }
   }
 }


### PR DESCRIPTION
If a bearer token and a Grafana Stack URL is supplied, then caching can be enabled for Athena data sources in a stack.