### PR TITLE
Update mandatory tags

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -3,8 +3,6 @@ data "aws_route53_zone" "this" {
   count    = var.hosted_zone_name != null ? 1 : 0
 
   name = var.hosted_zone_name
-
-  tags = var.tags
 }
 
 resource "aws_route53_record" "this" {


### PR DESCRIPTION
This pull request includes a small change to the `route53.tf` file. The change removes the `tags` attribute from the `aws_route53_zone` data block.

* [`route53.tf`](diffhunk://#diff-1910f4845d2896f70dbf7380f9e8ab51342191a24c34726b4ceba0548a998a8eL6-L7): Removed the `tags` attribute from the `aws_route53_zone` data block.


issue:
https://github.com/dfds/cloudplatform/issues/3139