### PR TITLE
share readonly token in 1pass

### DIFF
--- a/onepassword-item.tf
+++ b/onepassword-item.tf
@@ -49,7 +49,7 @@ resource "onepassword_item" "stack_vault_item" {
     field {
       label = "otlp-token (read-only)"
       type  = "CONCEALED"
-      value = grafana_cloud_access_policy_token.read_only[0].token
+      value = try(grafana_cloud_access_policy_token.read_only[0].token, "Not created for this entry!")
     }
   }
 
@@ -91,7 +91,7 @@ resource "onepassword_item" "stack_vault_item" {
         content {
         label = "password (read-only)"
         type  = "CONCEALED"
-        value = grafana_cloud_access_policy_token.read_only[0].token
+        value = try(grafana_cloud_access_policy_token.read_only[0].token, "Not created for this entry!")
       }
     }
   }
@@ -117,7 +117,7 @@ resource "onepassword_item" "stack_vault_item" {
         content {
         label = "password (read-only)"
         type  = "CONCEALED"
-        value = grafana_cloud_access_policy_token.read_only[0].token
+        value = try(grafana_cloud_access_policy_token.read_only[0].token, "Not created for this entry!")
       }
     }
   }
@@ -143,7 +143,7 @@ resource "onepassword_item" "stack_vault_item" {
         content {
         label = "password (read-only)"
         type  = "CONCEALED"
-        value = grafana_cloud_access_policy_token.read_only[0].token
+        value = try(grafana_cloud_access_policy_token.read_only[0].token, "Not created for this entry!")
       }
     }
   }

--- a/onepassword-item.tf
+++ b/onepassword-item.tf
@@ -86,10 +86,13 @@ resource "onepassword_item" "stack_vault_item" {
       type  = "CONCEALED"
       value = grafana_cloud_access_policy_token.write_only[0].token
     }
-    field {
-      label = "password (read-only)"
-      type  = "CONCEALED"
-      value = grafana_cloud_access_policy_token.read_only[0].token
+    dynamic "field" {
+        for_each = length(var.create_read_only_token) > 0 ? [1] : []
+        content {
+        label = "password (read-only)"
+        type  = "CONCEALED"
+        value = grafana_cloud_access_policy_token.read_only[0].token
+      }
     }
   }
   section {
@@ -109,10 +112,13 @@ resource "onepassword_item" "stack_vault_item" {
       type  = "CONCEALED"
       value = grafana_cloud_access_policy_token.write_only[0].token
     }
-    field {
-      label = "password (read-only)"
-      type  = "CONCEALED"
-      value = grafana_cloud_access_policy_token.read_only[0].token
+    dynamic "field" {
+        for_each = length(var.create_read_only_token) > 0 ? [1] : []
+        content {
+        label = "password (read-only)"
+        type  = "CONCEALED"
+        value = grafana_cloud_access_policy_token.read_only[0].token
+      }
     }
   }
   section {
@@ -132,10 +138,13 @@ resource "onepassword_item" "stack_vault_item" {
       type  = "CONCEALED"
       value = grafana_cloud_access_policy_token.write_only[0].token
     }
-    field {
-      label = "password (read-only)"
-      type  = "CONCEALED"
-      value = grafana_cloud_access_policy_token.read_only[0].token
+    dynamic "field" {
+        for_each = length(var.create_read_only_token) > 0 ? [1] : []
+        content {
+        label = "password (read-only)"
+        type  = "CONCEALED"
+        value = grafana_cloud_access_policy_token.read_only[0].token
+      }
     }
   }
 }

--- a/onepassword-item.tf
+++ b/onepassword-item.tf
@@ -87,7 +87,7 @@ resource "onepassword_item" "stack_vault_item" {
       value = grafana_cloud_access_policy_token.write_only[0].token
     }
     dynamic "field" {
-        for_each = length(var.create_read_only_token) > 0 ? [1] : []
+        for_each = var.create_read_only_token ? [1] : []
         content {
         label = "password (read-only)"
         type  = "CONCEALED"
@@ -113,7 +113,7 @@ resource "onepassword_item" "stack_vault_item" {
       value = grafana_cloud_access_policy_token.write_only[0].token
     }
     dynamic "field" {
-        for_each = length(var.create_read_only_token) > 0 ? [1] : []
+        for_each = var.create_read_only_token ? [1] : []
         content {
         label = "password (read-only)"
         type  = "CONCEALED"
@@ -139,7 +139,7 @@ resource "onepassword_item" "stack_vault_item" {
       value = grafana_cloud_access_policy_token.write_only[0].token
     }
     dynamic "field" {
-        for_each = length(var.create_read_only_token) > 0 ? [1] : []
+        for_each = var.create_read_only_token ? [1] : []
         content {
         label = "password (read-only)"
         type  = "CONCEALED"

--- a/onepassword-item.tf
+++ b/onepassword-item.tf
@@ -42,9 +42,14 @@ resource "onepassword_item" "stack_vault_item" {
       value = grafana_cloud_stack.this.id
     }
     field {
-      label = "otlp-password"
+      label = "otlp-password (write-only)"
       type  = "CONCEALED"
       value = grafana_cloud_access_policy_token.write_only[0].token
+    }
+    field {
+      label = "otlp-token (read-only)"
+      type  = "CONCEALED"
+      value = grafana_cloud_access_policy_token.read_only[0].token
     }
   }
 
@@ -77,9 +82,14 @@ resource "onepassword_item" "stack_vault_item" {
       value = grafana_cloud_stack.this.prometheus_user_id
     }
     field {
-      label = "password"
+      label = "password (write-only)"
       type  = "CONCEALED"
       value = grafana_cloud_access_policy_token.write_only[0].token
+    }
+    field {
+      label = "password (read-only)"
+      type  = "CONCEALED"
+      value = grafana_cloud_access_policy_token.read_only[0].token
     }
   }
   section {
@@ -95,9 +105,14 @@ resource "onepassword_item" "stack_vault_item" {
       value = grafana_cloud_stack.this.logs_user_id
     }
     field {
-      label = "password"
+      label = "password (write-only)"
       type  = "CONCEALED"
       value = grafana_cloud_access_policy_token.write_only[0].token
+    }
+    field {
+      label = "password (read-only)"
+      type  = "CONCEALED"
+      value = grafana_cloud_access_policy_token.read_only[0].token
     }
   }
   section {
@@ -113,9 +128,14 @@ resource "onepassword_item" "stack_vault_item" {
       value = grafana_cloud_stack.this.traces_user_id
     }
     field {
-      label = "password"
+      label = "password (write-only)"
       type  = "CONCEALED"
       value = grafana_cloud_access_policy_token.write_only[0].token
+    }
+    field {
+      label = "password (read-only)"
+      type  = "CONCEALED"
+      value = grafana_cloud_access_policy_token.read_only[0].token
     }
   }
 }


### PR DESCRIPTION
Expose Readonly token in 1Password so teams can use it for query data from their stacks in their own services

ticket ##250230479