### PR TITLE
Add Diagram OTEL Exporter with Conditional Endpoint Configuration

### DIFF
--- a/otel-collector.tf
+++ b/otel-collector.tf
@@ -21,7 +21,6 @@ resource "helm_release" "otel_collector" {
       collector_token = local.collecot_token_base64
       enable_collector_for_external_access = var.enable_collector_for_external_access
       diagram_otel_receiver_endpoint = var.diagram_otel_receiver_endpoint
-      send_to_diagram_receiver_feature_toggle = var.send_to_diagram_receiver_feature_toggle
     })
   ]
 }

--- a/otel-collector.tf
+++ b/otel-collector.tf
@@ -20,6 +20,8 @@ resource "helm_release" "otel_collector" {
       stack             = var.slug
       collector_token = local.collecot_token_base64
       enable_collector_for_external_access = var.enable_collector_for_external_access
+      diagram_otel_receiver_endpoint = var.diagram_otel_receiver_endpoint
+      send_to_diagram_receiver_feature_toggle = var.send_to_diagram_receiver_feature_toggle
     })
   ]
 }

--- a/otel-collector/values.yaml
+++ b/otel-collector/values.yaml
@@ -24,6 +24,12 @@ config:
       endpoint: ${otlphttp_endpoint}
       headers:
         Authorization: Basic ${stack_token}
+    %{ if send_to_diagram_receiver_feature_toggle ~}
+    otlpdiagram:
+      endpoint: ${diagram_otel_receiver_endpoint}
+      tls:
+        insecure: true 
+    %{ endif ~}
     debug: null
   processors:
     batch:
@@ -84,6 +90,7 @@ config:
         exporters:
           # - debug
           - otlphttp
+          - otlpdiagram
         processors:
           # - memory_limiter
           - batch

--- a/otel-collector/values.yaml
+++ b/otel-collector/values.yaml
@@ -25,7 +25,7 @@ config:
       headers:
         Authorization: Basic ${stack_token}
 %{ if diagram_otel_receiver_endpoint != "" ~}
-    otlpdiagram:
+    otlp/diagram:
       endpoint: ${diagram_otel_receiver_endpoint}
       tls:
         insecure: true 
@@ -91,7 +91,7 @@ config:
           # - debug
           - otlphttp
 %{ if diagram_otel_receiver_endpoint != "" ~}
-          - otlpdiagram
+          - otlp/diagram
 %{ endif ~}
         processors:
           # - memory_limiter

--- a/otel-collector/values.yaml
+++ b/otel-collector/values.yaml
@@ -24,7 +24,7 @@ config:
       endpoint: ${otlphttp_endpoint}
       headers:
         Authorization: Basic ${stack_token}
-    %{ if send_to_diagram_receiver_feature_toggle ~}
+    %{ if diagram_otel_receiver_endpoint != "" ~}
     otlpdiagram:
       endpoint: ${diagram_otel_receiver_endpoint}
       tls:
@@ -89,8 +89,10 @@ config:
       traces:
         exporters:
           # - debug
-          - otlphttp
+          - otlphttps
+          %{ if diagram_otel_receiver_endpoint != "" ~}
           - otlpdiagram
+          %{ endif ~}
         processors:
           # - memory_limiter
           - batch

--- a/otel-collector/values.yaml
+++ b/otel-collector/values.yaml
@@ -24,12 +24,12 @@ config:
       endpoint: ${otlphttp_endpoint}
       headers:
         Authorization: Basic ${stack_token}
-    %{ if diagram_otel_receiver_endpoint != "" ~}
+%{ if diagram_otel_receiver_endpoint != "" ~}
     otlpdiagram:
       endpoint: ${diagram_otel_receiver_endpoint}
       tls:
         insecure: true 
-    %{ endif ~}
+%{ endif ~}
     debug: null
   processors:
     batch:
@@ -90,9 +90,9 @@ config:
         exporters:
           # - debug
           - otlphttp
-          %{ if diagram_otel_receiver_endpoint != "" ~}
+%{ if diagram_otel_receiver_endpoint != "" ~}
           - otlpdiagram
-          %{ endif ~}
+%{ endif ~}
         processors:
           # - memory_limiter
           - batch

--- a/otel-collector/values.yaml
+++ b/otel-collector/values.yaml
@@ -89,7 +89,7 @@ config:
       traces:
         exporters:
           # - debug
-          - otlphttps
+          - otlphttp
           %{ if diagram_otel_receiver_endpoint != "" ~}
           - otlpdiagram
           %{ endif ~}

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,18 @@ variable "hosted_zone_name" {
   default     = null
 }
 
+variable "diagram_otel_receiver_endpoint" {
+  type        = string
+  description = "Endpoint for the diagram otel receiver"
+  default     = ""
+}
+
+variable "send_to_diagram_receiver_feature_toggle" {
+  type        = bool
+  description = "Feature toggle for sending traces to the diagram collector"
+  default     = false
+}
+
 variable "url" {
   type        = string
   description = "Custom URL for the Grafana instance. Should not be specified when passing `hosted_zone_name`"

--- a/variables.tf
+++ b/variables.tf
@@ -34,12 +34,6 @@ variable "diagram_otel_receiver_endpoint" {
   default     = ""
 }
 
-variable "send_to_diagram_receiver_feature_toggle" {
-  type        = bool
-  description = "Feature toggle for sending traces to the diagram collector"
-  default     = false
-}
-
 variable "url" {
   type        = string
   description = "Custom URL for the Grafana instance. Should not be specified when passing `hosted_zone_name`"


### PR DESCRIPTION
Add optional otlpdiagram exporter, enabled via diagram_otel_receiver_endpoint variable.