### PR TITLE
Split traces exporters into two

### DIFF
--- a/otel-collector/values.yaml
+++ b/otel-collector/values.yaml
@@ -111,7 +111,7 @@ config:
           - batch
         receivers:
           - otlp
-      traces/default:
+      traces:
         exporters:
           # - debug
           - otlphttp

--- a/otel-collector/values.yaml
+++ b/otel-collector/values.yaml
@@ -111,18 +111,29 @@ config:
           - batch
         receivers:
           - otlp
-      traces:
+      traces/default:
         exporters:
           # - debug
           - otlphttp
-%{ if diagram_otel_receiver_endpoint != "" ~}
-          - otlp/diagram
+        processors:
+          # - memory_limiter
+          - batch
+%{ if enable_collector_tailsampling ~}
+          - tail_sampling
 %{ endif ~}
+        receivers:
+          - otlp
+%{ if diagram_otel_receiver_endpoint != "" ~}
+      traces/diagram:
+        exporters:
+          # - debug
+          - otlp/diagram
         processors:
           # - memory_limiter
           - batch
         receivers:
           - otlp
+%{ endif ~}
 
 # Configuration for ports
 # nodePort is also allowed


### PR DESCRIPTION
1. Exporter for all traces, that can have tail sampling
2. Exporter for the diagram that should never have tail sampling.

The traces/default needs to be named traces as helm will add it if not existing.