### PR TITLE
Use same role for default stack service account as for Grafana stack users

### DIFF
--- a/stack.tf
+++ b/stack.tf
@@ -42,7 +42,7 @@ resource "grafana_cloud_stack_service_account" "editor" {
   stack_slug = grafana_cloud_stack.this.slug
 
   name        = local.service_account_editor_name
-  role        = "Viewer"
+  role        = "Editor"
   is_disabled = false
 }
 


### PR DESCRIPTION
This pull request makes a small but important change to the `stack.tf` Terraform configuration. The role assigned to the `editor` service account has been updated from "Viewer" to "Editor", granting it increased permissions.

Why this change?
Grafana Stack users are assigned Organisational Role Editor and so it should be the case for the service user that tribes are using for provisioning resources in their stack


* Changed the `role` for `grafana_cloud_stack_service_account.editor` from `"Viewer"` to `"Editor"` in `stack.tf`, increasing the service account's permissions.