### PR TITLE
remove ingressroute on otel collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ No modules.
 | [grafana_synthetic_monitoring_installation.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/synthetic_monitoring_installation) | resource |
 | [grafana_team.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/team) | resource |
 | [helm_release.otel_collector](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_manifest.ingress_route](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.middleware](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [onepassword_item.stack_vault_item](https://registry.terraform.io/providers/1Password/onepassword/latest/docs/resources/item) | resource |
 | [random_password.collector_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |

--- a/otel-collector.tf
+++ b/otel-collector.tf
@@ -35,39 +35,6 @@ resource "random_password" "collector_token" {
   override_special = "!#$%&*()-_=+?"
 }
 
-resource "kubernetes_manifest" "ingress_route" {
-  count      = var.deploy_otel_agent_k8s && var.enable_collector_for_external_access ? 1 : 0
-  manifest = {
-    "apiVersion" = "traefik.io/v1alpha1"
-    "kind"       = "IngressRoute"
-    "metadata" = {
-      "name"      = "otel-${var.route53_record_name}"
-      "namespace" = var.otel_collector_namespace
-    }
-    "spec" = {
-       "entryPoints" = []
-        "routes" = [
-          {
-            "kind" = "Rule"
-            "match" = "Host(`otel.dfds.cloud`) && PathPrefix(`/${var.route53_record_name}`)"
-            "middlewares" = [
-              {
-                "name"     = "otel-${var.route53_record_name}"
-                "priority" = 0
-              }
-            ]
-            "services" = [
-              {
-                "kind" = "Service"
-                "name" = "otel-${var.route53_record_name}"
-                "port" = "external"
-              }
-            ]
-          }
-        ]
-    }
-  }
-}
 
 resource "kubernetes_manifest" "middleware" {
   count      = var.deploy_otel_agent_k8s && var.enable_collector_for_external_access ? 1 : 0


### PR DESCRIPTION
This PR removes the ability to send otel data to old collectors after we switched to using https://github.com/dfds-internal/grafana-shared-otel-collectors for externally-facing traffic.
Next step is to remove the otel collectors completely after confirming that teams have updated their k8s applications  to point to the new collectors