### PR TITLE
Otel collector: 1password entry for external access by default and remove middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@
 | <a name="provider_grafana.cloud"></a> [grafana.cloud](#provider\_grafana.cloud) | >= 3.13.2 |
 | <a name="provider_grafana.stack"></a> [grafana.stack](#provider\_grafana.stack) | >= 3.13.2 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.14.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
 | <a name="provider_onepassword"></a> [onepassword](#provider\_onepassword) | >= 2.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.6.0 |
 
@@ -66,7 +65,6 @@ No modules.
 | [grafana_synthetic_monitoring_installation.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/synthetic_monitoring_installation) | resource |
 | [grafana_team.this](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/team) | resource |
 | [helm_release.otel_collector](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_manifest.middleware](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [onepassword_item.stack_vault_item](https://registry.terraform.io/providers/1Password/onepassword/latest/docs/resources/item) | resource |
 | [random_password.collector_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |

--- a/onepassword-item.tf
+++ b/onepassword-item.tf
@@ -17,12 +17,12 @@ resource "onepassword_item" "stack_vault_item" {
         value = "otel-${var.route53_record_name}.${var.otel_collector_namespace}.svc.cluster.local:4317"
       }
       field {
-        label = var.enable_collector_for_external_access ? "Collector ingress URL" : "Collector ingress URL (disabled)"
+        label = "Collector ingress URL"
         type  = "STRING"
-        value = var.enable_collector_for_external_access ? "otel.dfds.cloud/${var.route53_record_name}" : "PLACEHOLDER"
+        value = "otel.dfds.cloud/${var.route53_record_name}"
       }
       field {
-        label = var.enable_collector_for_external_access ? "Collector token": "Collector token (disabled)"
+        label = "Collector token"
         type  = "CONCEALED"
         value = local.collecot_token_base64
       }

--- a/otel-collector.tf
+++ b/otel-collector.tf
@@ -1,6 +1,6 @@
 locals {
   otlp_auth_header = var.create_write_only_token ? base64encode("${grafana_cloud_stack.this.id}:${grafana_cloud_access_policy_token.write_only[0].token}") : ""
-  collecot_token_base64 = var.deploy_otel_agent_k8s && var.enable_collector_for_external_access ? base64encode(random_password.collector_token[0].result) : "PLACEHOLDER"
+  collecot_token_base64 = var.deploy_otel_agent_k8s ? base64encode(random_password.collector_token[0].result) : "PLACEHOLDER"
 }
 
 resource "helm_release" "otel_collector" {
@@ -27,30 +27,9 @@ resource "helm_release" "otel_collector" {
   ]
 }
 
-
 resource "random_password" "collector_token" {
-  count            = var.deploy_otel_agent_k8s && var.enable_collector_for_external_access ? 1 : 0
+  count            = var.deploy_otel_agent_k8s ? 1 : 0
   length           = 40
   special          = true
   override_special = "!#$%&*()-_=+?"
-}
-
-
-resource "kubernetes_manifest" "middleware" {
-  count      = var.deploy_otel_agent_k8s && var.enable_collector_for_external_access ? 1 : 0
-  manifest = {
-    "apiVersion" = "traefik.io/v1alpha1"
-    "kind"       = "Middleware"
-    "metadata" = {
-      "name"      = "otel-${var.route53_record_name}"
-      "namespace" = var.otel_collector_namespace
-    }
-    "spec" = {
-      "stripPrefix" = {
-        "prefixes" = [
-          "/${var.route53_record_name}"
-        ]
-      }
-    }
-  }
 }


### PR DESCRIPTION
This pull request removes the dependency on the `enable_collector_for_external_access` variable for several resources and outputs, making the deployment process more straightforward. Additionally, it removes the unused `kubernetes_manifest.middleware` resource and updates documentation accordingly.

These changes are done as part of migration to the new collector setup