### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "branchPrefix": "feature/renovate/",
+    "extends": [
+        "local>dfds/renovate-config"
+    ],
     "terraform": {
         "managerFilePatterns": [
             "/\\.tf$/",
@@ -8,29 +10,29 @@
         ]
     },
     "packageRules": [
-        {
-            "matchUpdateTypes": [
-                "pin",
-                "digest",
-                "patch",
-                "lockFileMaintenance"
-            ],
-            "minimumReleaseAge": null,
-            "automerge": true,
-            "automergeType": "branch",
-            "matchCurrentVersion": "!/^0/",
-            "ignoreTests": true
-        },
-        {
-            "matchUpdateTypes": [
-                "minor",
-                "major"
-            ],
-            "minimumReleaseAge": "5 days",
-            "automerge": false,
-            "automergeType": "branch",
-            "matchCurrentVersion": "!/^0/",
-            "ignoreTests": true
-        }
-    ]
+    {
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "addLabels": [
+        "release:patch"
+      ]
+    },
+    {
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "addLabels": [
+        "release:minor"
+      ]
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "addLabels": [
+        "release:major"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the `renovate.json` configuration to standardize Renovate settings across the project and improve the labeling of dependency update pull requests. The main changes include extending a shared configuration and refining how update types are labeled.

Configuration standardization:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L3-R5): Now extends the shared configuration `local>dfds/renovate-config` for consistency with organization-wide Renovate settings.

Dependency update labeling:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L13-R35): Refactored `packageRules` to assign specific labels (`release:patch`, `release:minor`, `release:major`) to PRs based on the type of update, improving release tracking and automation.