### PR TITLE
Update workflow configurations to use versioned shared workflows and clean up unused steps

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -14,12 +14,4 @@ on:
 
 jobs:
   auto-release:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - id: release
-        uses: rymndhng/release-on-push-action@master
-        with:
-          bump_version_scheme: patch
-          tag_prefix: ""
+    uses: dfds/shared-workflows/.github/workflows/automation-auto-release.yml@v2.0.1

--- a/.github/workflows/block-on-hold-prs.yaml
+++ b/.github/workflows/block-on-hold-prs.yaml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-on-hold-prs.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-on-hold-prs.yml@v2.0.1

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -17,4 +17,3 @@ jobs:
           output-file: README.md
           output-method: inject
           git-push: "true"
-          tf_docs_git_push: 'true'

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -11,7 +11,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@main
+        uses: terraform-docs/gh-actions@v1.4.1
         with:
           working-dir: .
           output-file: README.md

--- a/.github/workflows/enforce-pr-labels.yaml
+++ b/.github/workflows/enforce-pr-labels.yaml
@@ -6,9 +6,4 @@ on:
     branches: [main]
 jobs:
   enforce-label:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: yogevbd/enforce-label-action@2.2.2
-        with:
-          REQUIRED_LABELS_ANY: "release:minor,release:major,release:patch,norelease"
-          REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['release:minor','release:major','release:patch', 'norelease']"
+    uses: dfds/shared-workflows/.github/workflows/automation-enforce-release-labels.yml@v2.0.1

--- a/.github/workflows/housekeeping.yaml
+++ b/.github/workflows/housekeeping.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   shared:
-    uses: dfds/shared-workflows/.github/workflows/automation-housekeeping.yml@master
+    uses: dfds/shared-workflows/.github/workflows/automation-housekeeping.yml@v2.0.1
     secrets: inherit
     with:
       delete_head_branch: true

--- a/.github/workflows/secret-detection.yaml
+++ b/.github/workflows/secret-detection.yaml
@@ -2,9 +2,9 @@ name: Gitleaks Manual
 
 on:
   push:
-    branches: [ "master", "main" ]
+    branches: [ main ]
   pull_request:
-    branches: [ "master", "main" ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use newer, shared workflow templates and makes minor improvements to workflow configuration. The main focus is on standardizing automation by referencing versioned shared workflows, improving maintainability and consistency across CI/CD processes.

**Workflow standardization and updates:**

* Updated the `auto-release`, `enforce-pr-labels`, `block-on-hold-prs`, and `housekeeping` workflows to use versioned shared workflows from `dfds/shared-workflows` (`v2.0.1`), replacing inline job definitions and references to the `master` branch. [[1]](diffhunk://#diff-896d2d27879dcb0ad2c8945dbb9646a9b6dfd3e98f4adcb788eb1fdfd21de71fL17-R17) [[2]](diffhunk://#diff-ac02a8df2005a99b45252e05338f32a3a98a70589056923b52e2d09fb3ca8b2aL9-R9) [[3]](diffhunk://#diff-1e230c3c4581758bd4507f8505e2a0b864f9981fbc4782c691e6616f70119365L10-R10) [[4]](diffhunk://#diff-ac2f23fc98e6ff17ba0096eb034c2d95a5f8c94ca3babd186b28d18470541402L9-R9)

**Configuration improvements:**

* Updated the `secret-detection.yaml` workflow to trigger only on the `main` branch, removing references to `master`.
* Removed the redundant `tf_docs_git_push` parameter from the documentation workflow configuration.