### PR TITLE
ensure 1pssword items created for all stacks

### DIFF
--- a/onepassword-item.tf
+++ b/onepassword-item.tf
@@ -7,25 +7,22 @@ resource "onepassword_item" "stack_vault_item" {
   url      = grafana_cloud_stack.this.url
 
 
-  dynamic "section" {
-    for_each = var.deploy_otel_agent_k8s ? [1] : []
-    content {
-      label = "OpenTelemetry Collector connection details (Kubernetes):"
-      field {
-        label = "endpoint"
-        type  = "STRING"
-        value = "otel-${var.route53_record_name}.${var.otel_collector_namespace}.svc.cluster.local:4317"
-      }
-      field {
-        label = "Collector ingress URL"
-        type  = "STRING"
-        value = "otel.dfds.cloud/${var.route53_record_name}"
-      }
-      field {
-        label = "Collector token"
-        type  = "CONCEALED"
-        value = local.collecot_token_base64
-      }
+  section {
+    label = "OpenTelemetry Collector connection details (Kubernetes):"
+    field {
+      label = "endpoint"
+      type  = "STRING"
+      value = "otel-${var.route53_record_name}.${var.otel_collector_namespace}.svc.cluster.local:4317"
+    }
+    field {
+      label = "Collector ingress URL"
+      type  = "STRING"
+      value = "otel.dfds.cloud/${var.route53_record_name}"
+    }
+    field {
+      label = "Collector token"
+      type  = "CONCEALED"
+      value = local.collecot_token_base64
     }
   }
 

--- a/otel-collector.tf
+++ b/otel-collector.tf
@@ -1,6 +1,6 @@
 locals {
   otlp_auth_header = var.create_write_only_token ? base64encode("${grafana_cloud_stack.this.id}:${grafana_cloud_access_policy_token.write_only[0].token}") : ""
-  collecot_token_base64 = var.deploy_otel_agent_k8s ? base64encode(random_password.collector_token[0].result) : "PLACEHOLDER"
+  collecot_token_base64 = base64encode(random_password.collector_token.result)
 }
 
 resource "helm_release" "otel_collector" {
@@ -28,7 +28,6 @@ resource "helm_release" "otel_collector" {
 }
 
 resource "random_password" "collector_token" {
-  count            = var.deploy_otel_agent_k8s ? 1 : 0
   length           = 40
   special          = true
   override_special = "!#$%&*()-_=+?"


### PR DESCRIPTION
This PR prepares ensures that 1password are published on all stacks and prepares for removing the helm chart installation for otel collectors in the future

**Simplification of OpenTelemetry Collector token management:**

* The `random_password.collector_token` resource is now always created (removal of the conditional `count` based on `var.deploy_otel_agent_k8s`), ensuring a token is generated regardless of deployment type.
* The local variable `collecot_token_base64` is now always set to the base64-encoded token, removing the previous conditional logic and placeholder value.

**Terraform configuration cleanup:**

* The `section` block for "OpenTelemetry Collector connection details (Kubernetes)" in `onepassword_item.stack_vault_item` is now always included, instead of being conditionally created.
* Removed unnecessary closing brace after the "OpenTelemetry Collector connection details (Kubernetes)" section, aligning with the new unconditional section definition.